### PR TITLE
♻️  restructure contacts/projects data files

### DIFF
--- a/CONTACTS.yaml
+++ b/CONTACTS.yaml
@@ -1,6 +1,6 @@
 #--------------------------------------------------------------------------
 # CF Council members (elected, staggered elections)
-# name, avatarUrl, company, description will be pulled from GitHub profile
+# name, avatarUrl, company, bio will be pulled from GitHub profile
 #
 # - login: github login
 #   term-start: most recent year of election
@@ -23,6 +23,8 @@ cf-council:
 
 #--------------------------------------------------------------------------
 # EGC Project Representatives (appointed by project governance process)
+# name, avatarUrl, company, bio will be pulled from GitHub profile
+#
 # - project: Project name (match key in PROJECTS.yaml)
 #   login: project representatives's github id
 #   avatarAlt: Optional. Avatar to show in addition to github avatar
@@ -40,10 +42,12 @@ egc:
 
 #--------------------------------------------------------------------------
 # Advisory Board members (appointed)
+# name, avatarUrl, company, bio will be pulled from GitHub profile
+#
 # - organization: Name (should match name in ...)
 #   login: representative's github id
 #   avatarAlt: Optional. Avatar to show in addition to github avatar
-#   description: Short description/bio to use instead of GH profile description
+#   bio: Short description/bio to use instead of GH profile description
 #
 advisory-board:
   - organization: Name
@@ -53,14 +57,21 @@ advisory-board:
 
 #--------------------------------------------------------------------------
 # Code of Conduct Panel members:
+# name, avatarUrl, company, bio will be pulled from GitHub profile
+#
 # - login: github id
 #   term-start: most recent year of election
 #   avatarAlt: Optional. Avatar to show in addition to github avatar
-#   description: Short description/bio to use instead of GH profile description
+#   bio: Short description/bio to use instead of GH profile description
+#
+# - login: github id
+#   term-start: most recent year of election
+#   see: other group to reference
 #
 cocp-panel:
   - login: ebullient
     term-start: 2024
+    see: cf-council
   - login: ...
     term-start: ...
   - login: ...

--- a/CONTACTS.yaml
+++ b/CONTACTS.yaml
@@ -1,65 +1,77 @@
 #--------------------------------------------------------------------------
 # CF Council members (elected, staggered elections)
-# - gh-id: github id
+# name, avatarUrl, company, description will be pulled from GitHub profile
+#
+# - login: github login
 #   term-start: most recent year of election
+#   avatarAlt: Optional. Avatar to show in addition to github avatar
+#   bio: Short description/bio to use instead of GH profile description
+#
 cf-council:
-  - gh-id: cealsair
+  - login: cealsair
     term-start: 2023
     role: Treasurer
-  - gh-id: ebullient
+  - login: ebullient
     term-start: 2023
+    avatarAlt: >-
+      https://www.ebullient.dev/images/devoxx-uk-2022-tiny.jpeg
     role: Chair
-  - gh-id: nmcl
+  - login: nmcl
     term-start: 2023
   - ...
   - ...
 
 #--------------------------------------------------------------------------
 # EGC Project Representatives (appointed by project governance process)
-# - name: Project name
-#   url: URL to github/gitlab organization
-#   gh-id: project representatives's github id
+# - project: Project name (match key in PROJECTS.yaml)
+#   login: project representatives's github id
+#   avatarAlt: Optional. Avatar to show in addition to github avatar
+#   bio: Short description/bio to use instead of GH profile description
+#
 egc:
-  - name: JBang
-    url: https://github.com/jbangdev
-    gh-id: maxandersen
-  - name: JReleaser
-    url: https://github.com/jreleaser
-    gh-id: aalmiray
-  - name: Morphia
-    url: https://github.com/morphiaorg
-    gh-id: evanchooly
-  - name: ...
-    gh-id: ...
+  - project: jbang
+    login: maxandersen
+  - project: jreleaser
+    login: aalmiray
+  - project: morphia
+    login: evanchooly
+  - project: ...
+    login: ...
 
 #--------------------------------------------------------------------------
 # Advisory Board members (appointed)
-# - organization: Name
-#   url: Website
-#   (..., optional social things, ...)
-#   gh-id: representative's github id
+# - organization: Name (should match name in ...)
+#   login: representative's github id
+#   avatarAlt: Optional. Avatar to show in addition to github avatar
+#   description: Short description/bio to use instead of GH profile description
+#
 advisory-board:
   - organization: Name
-    gh-id: ...
+    login: ...
   - organization: Name
-    gh-id: ...
+    login: ...
 
 #--------------------------------------------------------------------------
 # Code of Conduct Panel members:
-# - gh-id: github id
+# - login: github id
 #   term-start: most recent year of election
+#   avatarAlt: Optional. Avatar to show in addition to github avatar
+#   description: Short description/bio to use instead of GH profile description
+#
 cocp-panel:
-  - gh-id: ebullient
+  - login: ebullient
     term-start: 2024
-  - gh-id: ...
+  - login: ...
     term-start: ...
-  - gh-id: ...
+  - login: ...
     term-start: ...
 
 #--------------------------------------------------------------------------
 # Mailing lists referenced in bylaws and policies.
+#
 # See CONTRIBUTING.md, but usage is like this:
-# "send an email to the [`legal` mailing list][CONTACTS.yaml]"
+#    "send an email to the [`legal` mailing list][CONTACTS.yaml]"
+#
 mailing-list:
   announce: announce@commonhaus.org
   brand: brand@commonhaus.org
@@ -69,3 +81,4 @@ mailing-list:
   legal: legal@commonhaus.org
   report: report@commonhaus.org
   trademarks: legal@commonhaus.org
+

--- a/PROJECTS.yaml
+++ b/PROJECTS.yaml
@@ -1,0 +1,75 @@
+#
+# Summary about Commonhaus Foundation projects
+#
+# name: Project Name
+# home: preferred landing page
+# repo: gitlab/github/... organization or project repository
+# logo: Link to preferred logo to use on commonhaus.org website
+# wordmark: true if the above logo also contains the project name
+# description: a short-ish description of the project
+#
+# Unpublished (or early stage), use draft: true
+
+hibernate:
+  name: Hibernate
+  home: https://hibernate.org/
+  repo: https://github.com/hibernate/
+  logo: https://github.com/hibernate/hibernate.org/blob/production/images/hibernate-logo.svg?raw=true
+  wordmark: true
+  description: >
+    A powerful ORM framework for Java. Hibernate abstracts complex database interactions,
+    simplifying data management and persistence in enterprise Java applications.
+  draft: true
+
+jackson:
+  name: Jackson
+  home: https://github.com/FasterXML/jackson
+  repo: https://github.com/FasterXML/jackson
+  logo: https://avatars.githubusercontent.com/u/382692?s=200&v=4
+  wordmark: false
+  description: >
+    The go-to library for JSON processing in Java. Jackson offers fast and flexible parsing/generation
+    of JSON for Java applications, enabling seamless data interchange.
+
+jbang:
+  name: JBang
+  home: https://www.jbang.dev/
+  repo: https://github.com/jbangdev
+  logo: https://www.jbang.dev/assets/images/logo.png
+  wordmark: true
+  description: >
+    Unlock Java's scripting potential. JBang makes it easy to run Java applications as scripts
+    without the need for a project setup or build configuration. Ideal for quick experiments,
+    prototypes, or utility scripts.
+
+jreleaser:
+  name: JReleaser
+  home: https://jreleaser.org/
+  repo: https://github.com/jreleaser
+  logo: https://jreleaser.org/images/jreleaser-duke.png
+  wordmark: false
+  description: >
+    Automate your Java project releases with ease. JReleaser streamlines packaging and distribution
+    to multiple platforms, integrating with Maven, Gradle, and more. Simplify your release process,
+    from changelogs to deployment.
+
+morphia:
+  name: Morphia
+  home: https://morphia.dev/
+  repo: https://github.com/MorphiaOrg/
+  logo: https://github.com/MorphiaOrg/morphia-docs/blob/master/supplemental-ui/img/logo.png?raw=true
+  wordmark: false
+  description: >
+    Bridge the gap between Java and MongoDB. Morphia provides a lightweight type-safe mapping library
+    to simplify working with MongoDB documents using Java.
+
+openrewrite:
+  name: OpenRewrite
+  home: https://docs.openrewrite.org/
+  repo: https://github.com/openrewrite
+  logo: https://avatars.githubusercontent.com/u/61478321?s=200&v=4
+  wordmark: false
+  description: >
+    Automate the refactoring of your Java codebase. OpenRewrite offers scalable, safe, and idempotent
+    code transformations to modernize and maintain your applications.
+  draft: true


### PR DESCRIPTION
Move display metadata here (from website repo) to make it easier to find / keep up to date.

`CONTACTS.yaml` now focuses a bit more on the humans (alt avatar and description specified here to override what is picked up automatically from github).

Project summary + logo reference for website (need sanity checking) are now in `PROJECTS.yaml`