### PR TITLE
"open-source" to "open source"

### DIFF
--- a/COMMUNICATION.md
+++ b/COMMUNICATION.md
@@ -1,6 +1,6 @@
 # Join Our Community
 
-We rely on the contribution and participation of our members. Whether you're here to contribute code, share knowledge, or simply support the continued development of our open-source projects, our community spaces welcome everyone ready to make a positive impact.
+We rely on the contribution and participation of our members. Whether you're here to contribute code, share knowledge, or simply support the continued development of our open source projects, our community spaces welcome everyone ready to make a positive impact.
 
 ## Engage, learn, and share
 
@@ -12,7 +12,7 @@ We rely on the contribution and participation of our members. Whether you're her
 
 ## Support our efforts
 
-Every contribution powers the sustainable growth of our open-source projects. Even a small contribution can have a significant impact.
+Every contribution powers the sustainable growth of our open source projects. Even a small contribution can have a significant impact.
 
 <a href="https://github.com/sponsors/commonhaus" class="text button">Become a Sponsor</a>
 
@@ -25,7 +25,7 @@ Every contribution, regardless of size, is deeply appreciated. To express our gr
 
 [Membership](./bylaws/2-cf-membership.md) at the Commonhaus Foundation opens the door to active participation in shaping our future.
 
-By becoming a member, you're not just supporting us financially; you're joining a community of individuals dedicated to the sustainable development of open-source projects. Members can hold CF offices, vote in Foundation elections, and influence our strategic direction. They also can show off their support with a `@commonhaus.dev` email address.
+By becoming a member, you're not just supporting us financially; you're joining a community of individuals dedicated to the sustainable development of open source projects. Members can hold CF offices, vote in Foundation elections, and influence our strategic direction. They also can show off their support with a `@commonhaus.dev` email address.
 
 - **How to Join**: Membership is initiated through [**sponsorship** (GitHub)](https://github.com/sponsors/commonhaus) and participation.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -84,7 +84,7 @@ It also supports a broader array of OSI-approved licenses.
 
 ## Why not the Apache Software Foundation?
 
-The Apache Software Foundation (ASF) is renowned for its support of a diverse range of open-source projects,
+The Apache Software Foundation (ASF) is renowned for its support of a diverse range of open source projects,
 offering a structured environment with specific infrastructure requirements,
 including mailing lists,
 and a governance model centered around the Apache Software License (Apache-2.0).
@@ -116,7 +116,7 @@ leaving projects free to navigate these aspects as they see fit.
 
 ## Why not the Linux Foundation?
 
-The Linux Foundation (LF) is a respected home for thousands of open-source projects,
+The Linux Foundation (LF) is a respected home for thousands of open source projects,
 whether as part of its broader umbrella for unfunded projects or within its various
 sub-foundations (each with its own set of benefits and governance structures).
 LF Projects have the opportunity to operate with a significant degree of independence,
@@ -124,7 +124,7 @@ especially as unfunded initiatives,
 though they may receive fewer direct benefits compared to those in sub-foundations.
 
 Like the Linux Foundation,
-the Commonhaus Foundation aims to be a welcoming home for open-source projects,
+the Commonhaus Foundation aims to be a welcoming home for open source projects,
 offering an alternative for those seeking a community with shared interests
 and a more tailored support structure.
 We provide a space for projects that value a smaller, more focused community engagement,

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,7 +4,7 @@ status: draft
 
 # Commonhaus Foundation Project Governance
 
-Welcome to the Commonhaus Foundation (CF), a nonprofit dedicated to nurturing open-source projects through collaborative innovation.
+Welcome to the Commonhaus Foundation (CF), a nonprofit dedicated to nurturing open source projects through collaborative innovation.
 
 ## Governance overview
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # <img src="https://www.commonhaus.org/images/CF_icon_default.svg" alt="" width="32" height="32"> Commonhaus Foundation
 
-The Commonhaus Foundation (CF) champions open-source innovation, focusing on the long-term growth and stability of  community-driven open-source projects.
-We empower contributors to drive the evolution of vital open-source libraries and frameworks through collaborative innovation.
+The Commonhaus Foundation (CF) champions open source innovation, focusing on the long-term growth and stability of  community-driven open source projects.
+We empower contributors to drive the evolution of vital open source libraries and frameworks through collaborative innovation.
 
 ## What sets Commonhaus apart
 
-Inspired by the [The Codehaus][codehaus], CF offers a balanced approach to governance and support, designed for the unique needs of established open-source projects.
+Inspired by the [The Codehaus][codehaus], CF offers a balanced approach to governance and support, designed for the unique needs of established open source projects.
 
 - **Stable, long-term home**: CF acknowledges the evolving nature of projects. By providing a neutral home, we offer an anchor supporting growth over time. We're committed to ensuring smooth transitions and fostering long-term resilience with thoughtful succession planning.
 
@@ -15,15 +15,15 @@ Inspired by the [The Codehaus][codehaus], CF offers a balanced approach to gover
 
 ## Our mission, vision and focus
 
-We want to empower a diverse community of developers, contributors, and users to create, maintain, and evolve open-source libraries and frameworks, ensuring long-term growth and stability through shared stewardship and community collaboration.
+We want to empower a diverse community of developers, contributors, and users to create, maintain, and evolve open source libraries and frameworks, ensuring long-term growth and stability through shared stewardship and community collaboration.
 
-We envision a welcoming ecosystem where open-source projects grow through collaboration and mutual support, simplifying participation for all by moving beyond conventional governance hurdles.
+We envision a welcoming ecosystem where open source projects grow through collaboration and mutual support, simplifying participation for all by moving beyond conventional governance hurdles.
 
 We prioritize **Application Frameworks** and **Libraries** that are critical for developers. We support self-governing, code-centric projects, steering clear of specifications and standards debates to focus on tangible outcomes.
 
 ## Community and sponsorship
 
-Our doors are open to everyone passionate about open-source innovation. We invite all individuals, not just code contributors, to participate and help shape our organization. Our [Bylaws][] detail membership and governance, emphasizing collaboration, diverse perspectives, and advisory input from our [Advisory Board][cfab] to align sponsorship with community interests.
+Our doors are open to everyone passionate about open source innovation. We invite all individuals, not just code contributors, to participate and help shape our organization. Our [Bylaws][] detail membership and governance, emphasizing collaboration, diverse perspectives, and advisory input from our [Advisory Board][cfab] to align sponsorship with community interests.
 
 ## Get involved
 

--- a/agreements/bootstrapping/2024-03-12-bootstrapping-jbang.md
+++ b/agreements/bootstrapping/2024-03-12-bootstrapping-jbang.md
@@ -6,7 +6,7 @@ status: draft
 - Project: jbangdev / jbang
 - EGC representative: maxandersen
 
-This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open-source projects.
+This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open source projects.
 
 - [EGC Quorum Establishment](#egc-quorum-establishment)
 - [Preliminary Commitment](#preliminary-commitment)

--- a/agreements/bootstrapping/2024-03-13-bootstrapping-jreleaser.md
+++ b/agreements/bootstrapping/2024-03-13-bootstrapping-jreleaser.md
@@ -6,7 +6,7 @@ status: draft
 - Project: jreleaser / jreleaser
 - EGC representative: aalmiray
 
-This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open-source projects.
+This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open source projects.
 
 - [EGC Quorum Establishment](#egc-quorum-establishment)
 - [Preliminary Commitment](#preliminary-commitment)

--- a/agreements/bootstrapping/2024-03-15-bootstrapping-morphia.md
+++ b/agreements/bootstrapping/2024-03-15-bootstrapping-morphia.md
@@ -6,7 +6,7 @@ status: draft
 - Project: Morphia
 - EGC representative: evanchooly
 
-This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open-source projects.
+This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open source projects.
 
 - [EGC Quorum Establishment](#egc-quorum-establishment)
 - [Preliminary Commitment](#preliminary-commitment)

--- a/agreements/bootstrapping/2024-03-25-bootstrapping-jackson.md
+++ b/agreements/bootstrapping/2024-03-25-bootstrapping-jackson.md
@@ -6,7 +6,7 @@ status: draft
 - Project: FasterXML / jackson
 - EGC representative: cowtowncoder
 
-This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open-source projects.
+This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open source projects.
 
 - [EGC Quorum Establishment](#egc-quorum-establishment)
 - [Preliminary Commitment](#preliminary-commitment)

--- a/agreements/bootstrapping/2024-03-25-bootstrapping-openrewrite.md
+++ b/agreements/bootstrapping/2024-03-25-bootstrapping-openrewrite.md
@@ -6,7 +6,7 @@ status: draft
 - Project: OpenRewrite
 - EGC representative: jkschneider
 
-This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open-source projects.
+This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open source projects.
 
 - [Commonhaus Foundation Bootstrapping Agreement](#commonhaus-foundation-bootstrapping-agreement)
   - [EGC Quorum Establishment](#egc-quorum-establishment)

--- a/agreements/bootstrapping/2024-04-02-bootstrapping-hibernate.md
+++ b/agreements/bootstrapping/2024-04-02-bootstrapping-hibernate.md
@@ -6,7 +6,7 @@ status: draft
 - Project: hibernate / Hibernate
 - EGC representative: gavinking
 
-This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open-source projects.
+This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open source projects.
 
 - [EGC Quorum Establishment](#egc-quorum-establishment)
 - [Preliminary Commitment](#preliminary-commitment)

--- a/agreements/bootstrapping/bootstrapping.md
+++ b/agreements/bootstrapping/bootstrapping.md
@@ -6,7 +6,7 @@ status: draft
 - Project: [Insert GitHub Organization and Project name here]
 - EGC representative: [Insert GitHub Username here]
 
-This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open-source projects.
+This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open source projects.
 
 - [EGC Quorum Establishment](#egc-quorum-establishment)
 - [Preliminary Commitment](#preliminary-commitment)

--- a/bylaws/0-preface.md
+++ b/bylaws/0-preface.md
@@ -4,14 +4,14 @@ weight: 0
 ---
 # Preface
 
-Welcome to the Commonhaus Foundation (CF), a collective dedicated to nurturing open-source projects through collaboration and innovation. These bylaws provide a detailed guide to our governance structure and outline your role within our community.
+Welcome to the Commonhaus Foundation (CF), a collective dedicated to nurturing open source projects through collaboration and innovation. These bylaws provide a detailed guide to our governance structure and outline your role within our community.
 
 ## Key Terms
 
 - **[CF Council (CFC)][cfc]**: Governs CF operations and strategic direction.
 - **[CF Advisory Board][cfab]**: Comprises representatives from organizations providing financial support to the CF. They provide strategic insight to the CFC.
 - **[General Members][membership]**: Individuals supporting CF’s mission. Members in good standing participate in CF activities and vote in elections.
-- **[Projects][project]**: Collaborative open-source initiatives under CF, including assets like code, trademarks, and domains.
+- **[Projects][project]**: Collaborative open source initiatives under CF, including assets like code, trademarks, and domains.
     - **[Code Owners][plco]**: Maintain the quality and consistency of project code.
     - **[Project Leaders][plco]**: Guide project governance and decision-making. Along with the CFC, they form the [**Extended Governance Committee (EGC)**][egc] for critical decisions like bylaw amendments.
 

--- a/bylaws/1-purpose.md
+++ b/bylaws/1-purpose.md
@@ -4,11 +4,11 @@ weight: 1
 ---
 # Purpose and Non-profit Status
 
-The Commonhaus Foundation (CF) is dedicated to open-source innovation and collaboration. Our nonprofit purposes are to:
+The Commonhaus Foundation (CF) is dedicated to open source innovation and collaboration. Our nonprofit purposes are to:
 
 1. Serve the community by facilitating collaboration between creators and consumers of CF projects.
-2. Empower a diverse community of contributors to create, maintain, enhance, and secure vital open-source libraries and frameworks.
-3. Foster and support the longevity of open-source projects through community collaboration and shared stewardship.
+2. Empower a diverse community of contributors to create, maintain, enhance, and secure vital open source libraries and frameworks.
+3. Foster and support the longevity of open source projects through community collaboration and shared stewardship.
 4. Promote the exchange of ideas and information within the technology community.
 5. Support the common interests of businesses and professionals to improve the economic climate and business development of commercial enterprises in the technology sector.
 

--- a/bylaws/2-cf-membership.md
+++ b/bylaws/2-cf-membership.md
@@ -4,7 +4,7 @@ weight: 2
 ---
 # Membership
 
-The Commonhaus Foundation (CF) is a membership organization. Your involvement in the CF, whether as a project representative or a general member, shapes the future of open-source innovation. We value each contribution and encourage active participation in our diverse and vibrant community.
+The Commonhaus Foundation (CF) is a membership organization. Your involvement in the CF, whether as a project representative or a general member, shapes the future of open source innovation. We value each contribution and encourage active participation in our diverse and vibrant community.
 
 The following section outlines the different types of membership and the process for becoming a member.
 
@@ -18,7 +18,7 @@ The following section outlines the different types of membership and the process
 
 ## Projects
 
-A **project** within the CF represents collaborative innovation in open-source technology. These projects are dynamic collectives of individual contributors, functioning as self-organizing units rather than formal legal entities.[^1]
+A **project** within the CF represents collaborative innovation in open source technology. These projects are dynamic collectives of individual contributors, functioning as self-organizing units rather than formal legal entities.[^1]
 
 **Flexible and Inclusive Structure:** Projects can vary in size and scope, ranging from individual repositories to entire collections of repositories. Whether it's a single focused effort or a collection of related initiatives, each project is defined by common goals and shared assets, including code, trademarks, and domains.
 

--- a/bylaws/3-cf-council.md
+++ b/bylaws/3-cf-council.md
@@ -33,7 +33,7 @@ An up-to-date list of Councilors will be maintained in the `cf-council` [CONTACT
 
 **Structure:** The CFC is composed of a minimum of 3 elected Councilors: 1 [CFC Chairperson](#cfc-chairperson) and at least 2 members-at-large.
 
-**Selection and Elections:** The selection process for Councilors is designed to reflect the diversity of the open-source community.
+**Selection and Elections:** The selection process for Councilors is designed to reflect the diversity of the open source community.
 
 - Any member that has been active within the CF community for at least six months can run or be nominated.
 - Every active member is entitled to one vote in annual [elections][].

--- a/bylaws/7-indemnification-dissolution.md
+++ b/bylaws/7-indemnification-dissolution.md
@@ -6,7 +6,7 @@ weight: 7
 
 The Commonhaus Foundation (CF) is committed to protecting its team—councilors, officers, employees, and agents—against legal expenses and liabilities they might face while performing their duties in good faith for the Foundation. In simple terms, if individuals are acting with the Foundation's best interests in mind and within the bounds of the law, the Foundation aims to support them.
 
-Below are the detailed policies that outline this support, including the circumstances under which it applies, the process for claiming indemnification, and the Foundation’s rights to procure insurance for further protection. Additionally, the Foundation's approach to dissolution is outlined, ensuring any remaining assets are used to further open-source projects in alignment with our mission.
+Below are the detailed policies that outline this support, including the circumstances under which it applies, the process for claiming indemnification, and the Foundation’s rights to procure insurance for further protection. Additionally, the Foundation's approach to dissolution is outlined, ensuring any remaining assets are used to further open source projects in alignment with our mission.
 
 - [Insurance](#insurance)
 - [Indemnification](#indemnification)
@@ -86,7 +86,7 @@ Relevant Florida Statutes:
 
 ## Dissolution and Asset Distribution
 
-In the unfortunate event that the Commonhaus Foundation must dissolve, we commit to a responsible and lawful closure process, prioritizing the continuity and integrity of our open-source projects.
+In the unfortunate event that the Commonhaus Foundation must dissolve, we commit to a responsible and lawful closure process, prioritizing the continuity and integrity of our open source projects.
 Given that CF projects represent collaborative effort of individual contributors, the dissolution process will respect the unique structure and community-driven nature of each project.
 
 Relevant Florida Statutes:

--- a/policies/ip-policy.md
+++ b/policies/ip-policy.md
@@ -10,9 +10,9 @@ All new inbound code contributions to individual Projects are made pursuant to t
 ## License Selection and Usage
 
 > [!TIP]
-> CF supports a wide range of open-source licenses to ensure projects can choose what's best for them. We’ll check these licenses, including for any software they rely on, to make sure everything works together without legal issues.
+> CF supports a wide range of open source licenses to ensure projects can choose what's best for them. We’ll check these licenses, including for any software they rely on, to make sure everything works together without legal issues.
 
-CF projects can use any [open-source license approved by the Open Source Initiative](https://opensource.org/licenses/) (OSI).
+CF projects can use any [open source license approved by the Open Source Initiative](https://opensource.org/licenses/) (OSI).
 
 The CF will review Project Code Licenses and the licenses of its dependencies to ensure that all components of the project are compatible under the chosen license and do not introduce legal conflicts or restrictions that could affect the Project's or Foundation's operation.
 
@@ -70,12 +70,12 @@ Project leaders should ensure compliance with this policy and provide clear guid
 ## Collaborations and External Projects
 
 > [!TIP]
-> Always check and follow the license rules of any external open-source projects we interact with.
+> Always check and follow the license rules of any external open source projects we interact with.
 > If an upstream project uses a non-OSI license, the [CF Council (CFC)][cfc] can approve exceptions if needed.
 
-Engaging with external open-source projects requires awareness and respect for their licensing terms to ensure our contributions are legally compatible. This ensures our projects can seamlessly integrate or collaborate with these external projects without infringing on their or our license terms.
+Engaging with external open source projects requires awareness and respect for their licensing terms to ensure our contributions are legally compatible. This ensures our projects can seamlessly integrate or collaborate with these external projects without infringing on their or our license terms.
 
-When collaborating with external open-source projects ("Upstream Projects") conform to all license requirements of the Upstream Projects, including dependencies, leveraged by the Project. If an alternative inbound or outbound license is required for compliance with the license for an Upstream Project or is otherwise required to achieve the Commonhaus Foundation’s, or an individual Project’s, objectives, the CFC may approve the use of an alternative license for inbound or outbound contributions on an exception basis.
+When collaborating with external open source projects ("Upstream Projects") conform to all license requirements of the Upstream Projects, including dependencies, leveraged by the Project. If an alternative inbound or outbound license is required for compliance with the license for an Upstream Project or is otherwise required to achieve the Commonhaus Foundation’s, or an individual Project’s, objectives, the CFC may approve the use of an alternative license for inbound or outbound contributions on an exception basis.
 
 ### Copyright Statements
 

--- a/policies/trademark-policy.md
+++ b/policies/trademark-policy.md
@@ -3,7 +3,7 @@ status: draft
 ---
 # Trademark Policy
 
-This document provides guidelines for the use of the Commonhaus Foundation's (CF) trademarks, ensuring they are used in a manner that promotes our open-source projects while maintaining their integrity and value.
+This document provides guidelines for the use of the Commonhaus Foundation's (CF) trademarks, ensuring they are used in a manner that promotes our open source projects while maintaining their integrity and value.
 
 Our trademarks, including the Commonhaus Foundation name, logo, and any project names, represent the quality and reliability our community has come to expect.
 If you have any questions or need further clarification, please [contact us](#contact-and-further-information).


### PR DESCRIPTION
Some tech writers disagree here, so usage is mixed, sometimes.

If you think something should remain hyphenated, use the +- to put it back.

