### PR TITLE
🔖 draft membership agreements

### DIFF
--- a/agreements/membership/README.md
+++ b/agreements/membership/README.md
@@ -1,0 +1,5 @@
+# Membership agreements
+
+These agreements will be rendered and recorded as part of the membership application and renewal process. They are designed to ensure that members understand and agree to the terms and conditions of membership in the Commonhaus Foundation (CF).
+
+Affirmed responses will not be stored in this repository, but will be recorded in the Commonhaus Foundation's membership database.

--- a/agreements/membership/egc-representative-agreement.yaml
+++ b/agreements/membership/egc-representative-agreement.yaml
@@ -1,0 +1,34 @@
+title: "Extended Governance Committee (EGC) Membership Agreement"
+version: "initial draft"
+preamble: |
+  The Commonhaus Foundation uses GitHub as its primary platform for project management and collaboration.
+  EGC members must have a GitHub account to participate in CF discussions and votes.
+
+  As a project representative to the Extended Governance Committee (EGC), I affirm the following:
+
+attestations:
+  bylaws:
+    title: "Commonhaus Foundation Bylaws"
+    body: |
+      I have read the following sections of the Commonhaus Foundation Bylaws and understand my obligations:
+
+      - [Project Representation](https://www.commonhaus.org/bylaws/2-cf-membership.md#project-representation)
+      - [Composition of the EGC](https://www.commonhaus.org/bylaws/3-cf-council.md#extended-governance-committee-egc)
+      - [Decision Making](https://www.commonhaus.org/bylaws/decision-making.html)
+      - [Matters requiring EGC approval](https://www.commonhaus.org/bylaws/3-cf-council.md#matters-requiring-egc-approval)
+      - [Electronic Participation and Voting](https://www.commonhaus.org/bylaws/cf-council.html#electronic-participation-and-decision-making)
+
+  coc:
+    title: "Code of Conduct"
+    body: |
+      I have read the [Code of Conduct](https://www.commonhaus.org/policies/code-of-conduct/) and agree to adhere to its terms.
+
+  email:
+    title: "Commonhaus email address"
+    body: |
+      I have read the [Forward Email Terms of Service](https://forwardemail.net/en/terms) and agree to adhere
+      to its terms when using my `commonhaus.dev` email address.
+
+      > [!NOTE]
+      > If you accept these terms, a `commonhaus.dev` email address will be created for your GitHub Login if it
+      > does not already exist. It will initially forward to the public address listed in your GitHub profile.

--- a/agreements/membership/membership-application.yaml
+++ b/agreements/membership/membership-application.yaml
@@ -1,0 +1,29 @@
+title: "Commonhaus Foundation Membership Application"
+version: "initial draft"
+preamble: |
+  I would like to apply for membership to the Commonhaus Foundation (CF).
+
+attestations:
+  bylaws:
+    title: "Commonhaus Foundation Bylaws"
+    body: |
+      I have read the following sections of the Commonhaus Foundation Bylaws and understand my obligations:
+
+      - [Membership](https://www.commonhaus.org/bylaws/cf-membership.html)
+      - [Decision Making](https://www.commonhaus.org/bylaws/decision-making.html)
+
+  coc:
+    title: "Code of Conduct"
+    body: |
+      I have read the [Code of Conduct](https://www.commonhaus.org/policies/code-of-conduct/) and agree to adhere to its terms.
+
+  email:
+    title: "Commonhaus email address"
+    body: |
+      I have read the [Forward Email Terms of Service](https://forwardemail.net/en/terms) and agree to adhere
+      to its terms when using my `commonhaus.dev` email address.
+
+      > [!NOTE]
+      > If you accept these terms, a `commonhaus.dev` email address will be created for your GitHub Login if it
+      > does not already exist. It will initially forward to the public address listed in your GitHub profile.
+

--- a/agreements/membership/membership-renewal.yaml
+++ b/agreements/membership/membership-renewal.yaml
@@ -1,0 +1,29 @@
+title: "Commonhaus Foundation Membership Renewal"
+version: "initial draft"
+preamble: |
+  I would like to renew my membership to the Commonhaus Foundation (CF).
+
+attestations:
+  bylaws:
+    title: "Commonhaus Foundation Bylaws"
+    body: |
+      I have read the following sections of the Commonhaus Foundation Bylaws and understand my obligations:
+
+      - [Membership](https://www.commonhaus.org/bylaws/cf-membership.html)
+      - [Decision Making](https://www.commonhaus.org/bylaws/decision-making.html)
+
+  coc:
+    title: "Code of Conduct"
+    body: |
+      I have read the [Code of Conduct](https://www.commonhaus.org/policies/code-of-conduct/) and agree to adhere to its terms.
+
+  email:
+    title: "Commonhaus email address"
+    body: |
+      I have read the [Forward Email Terms of Service](https://forwardemail.net/en/terms) and agree to adhere
+      to its terms when using my `commonhaus.dev` email address.
+
+      > [!NOTE]
+      > If you accept these terms, a `commonhaus.dev` email address will be created for your GitHub Login if it
+      > does not already exist. It will initially forward to the public address listed in your GitHub profile.
+


### PR DESCRIPTION
These will be used with membership management automation and will not committed by users into this repository. I think it is important, however, to have the text of the agreement in a visible place.

Suggestions/revisions are welcome, but this is a draft. I want the documents available for testing with other tools. Will look for content approval before asking folks to actually sign it (at which point the version will be a date, rather than "draft".