### PR TITLE
Bylaws: revise indemnification language

### DIFF
--- a/bylaws/8-indemnification-dissolution.md
+++ b/bylaws/8-indemnification-dissolution.md
@@ -33,9 +33,12 @@ Subject to the limitations set forth in this Section, the Foundation shall, to t
 The Foundation may, at the discretion of the CF Council (CFC), extend indemnification to employees, committee members, and other agents of the Foundation as determined appropriate by the CFC.
 
 > [!TIP]
-> This means the Foundation will cover costs and losses for council members and officers who are sued because of their role in the Foundation, as long as they acted honestly and in the Foundation's best interest.
+> This means the Foundation will cover costs and losses for council members and [officers][] who are sued because of their role in the Foundation, as long as they acted honestly and in the Foundation's best interest.
 >
-> The council can choose to extend this coverage to staff and committee members if they decide it’s appropriate.
+> The council can choose to extend this coverage to staff and [committee members][committee] if they decide it’s appropriate.
+
+[officers]: ./3-cf-council.md#officer-roles-and-appointment
+[committee]: ./3-cf-council.md#committees-and-delegation
 
 **Standard of Conduct.**
 

--- a/bylaws/8-indemnification-dissolution.md
+++ b/bylaws/8-indemnification-dissolution.md
@@ -38,7 +38,8 @@ The Foundation may, at the discretion of the CF Council (CFC), extend indemnific
 > The council can choose to extend this coverage to staff and committee members if they decide it’s appropriate.
 
 **Standard of Conduct.**
-This indemnification extends to all reasonable expenses (including attorneys’ fees), judgments, fines, and other amounts paid in settlement by the person in connection with the action, so long as the person:
+
+This indemnification extends to all reasonable expenses (like legal fees), judgments, fines, and settlement amounts that a person may have to pay in connection with a legal action, so long as the person:
 
 1. acted in good faith and in a manner they reasonably believed to be consistent with the best interests of the Foundation, and
 2. had no reason to believe their conduct was unlawful, in the case of criminal matters.
@@ -47,7 +48,8 @@ This indemnification does not extend to a person who is found liable to the Foun
 Otherwise, the outcome of an action will not alone create a presumption that a person did not act in good faith, in the best interests of the Foundation, or with lawful intent.
 
 > [!TIP]
-> If the Foundation sues someone or they are found liable to the Foundation, they won't be covered. Just being sued doesn't mean they did something wrong.
+> If the Foundation brings a lawsuit against a person, or if the person is found responsible for wrongdoing in such a lawsuit, they will not be covered by this indemnification.
+> Being involved in a lawsuit does not mean the person did something wrong.
 
 Relevant Florida Statutes:
 

--- a/bylaws/8-indemnification-dissolution.md
+++ b/bylaws/8-indemnification-dissolution.md
@@ -22,54 +22,69 @@ The CF Council (CFC) shall assess the Foundation's risks and evaluate whether to
 
 Relevant Florida Statute:
 
-- [607.0857](http://www.leg.state.fl.us/Statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0600-0699/0607/Sections/0607.0857.html) Insurance.
+- [607.0857](http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0600-0699/0607/Sections/0607.0857.html) Insurance.
 
 ## Indemnification
 
 ### Scope of Indemnification and Standard of Conduct
 
-Subject to the limitations set forth in this Section,
-the Foundation must indemnify directors (councilors), Officers, employees, and agents of the Foundation
-from any action, suit, or proceeding (whether civil, criminal, administrative or investigative)
-arising from that person’s role in the Foundation or service at the request of the Foundation.
+Subject to the limitations set forth in this Section, the Foundation shall, to the fullest extent permitted by applicable law, indemnify and hold harmless any person (a “Covered Person”) who is made a party to, or threatened to be made a party to, any action, suit, or proceeding, whether civil, criminal, administrative, or investigative (other than an action by or in the right of the Foundation) (a “Proceeding”), by reason of the fact that they are or were a council member (acting as a director) or officer of the Foundation, against all liability and loss suffered and expenses (including attorneys' fees) reasonably incurred by that person.
+
+The Foundation may, at the discretion of the CF Council (CFC), extend indemnification to employees, committee members, and other agents of the Foundation as determined appropriate by the CFC.
+
+> [!TIP]
+> This means the Foundation will cover costs and losses for council members and officers who are sued because of their role in the Foundation, as long as they acted honestly and in the Foundation's best interest.
+>
+> The council can choose to extend this coverage to staff and committee members if they decide it’s appropriate.
 
 **Standard of Conduct.**
 This indemnification extends to all reasonable expenses (including attorneys’ fees), judgments, fines, and other amounts paid in settlement by the person in connection with the action, so long as the person:
-(1) acted in good faith and in a manner they reasonably believed to be consistent with the best interests of the Foundation, and
-(2) had no reason to believe their conduct was unlawful, in the case of criminal matters.
+
+1. acted in good faith and in a manner they reasonably believed to be consistent with the best interests of the Foundation, and
+2. had no reason to believe their conduct was unlawful, in the case of criminal matters.
 
 This indemnification does not extend to a person who is found liable to the Foundation in an action brought by the Foundation, or to enforce the Foundation's rights.
 Otherwise, the outcome of an action will not alone create a presumption that a person did not act in good faith, in the best interests of the Foundation, or with lawful intent.
 
+> [!TIP]
+> If the Foundation sues someone or they are found liable to the Foundation, they won't be covered. Just being sued doesn't mean they did something wrong.
+
 Relevant Florida Statutes:
 
 - [607.0851](http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0600-0699/0607/Sections/0607.0851.html) Permissible indemnification.
-- [617.0831](http://www.leg.state.fl.us/Statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0600-0699/0617/Sections/0617.0831.html) Indemnification and liability of officers, directors, employees, and agents.
-- [617.0834](http://www.leg.state.fl.us/Statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0600-0699/0617/Sections/0617.0834.html) Officers and directors of certain corporations and associations not for profit; immunity from civil liability.
+- [617.0831](http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0600-0699/0617/Sections/0617.0831.html) Indemnification and liability of officers, directors, employees, and agents.
+- [617.0834](http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0600-0699/0617/Sections/0617.0834.html) Officers and directors of certain corporations and associations not for profit; immunity from civil liability.
 
 ### Authorization by the Council
 
-The Foundation will only indemnify a person if the CFC first determines that indemnification is proper under the circumstances because the
-person has met the [standard of conduct](#scope-of-indemnification-and-standard-of-conduct).
+The Foundation will only indemnify a person if the CF Council (CFC) first determines that indemnification is proper under the circumstances because the person has met the [standard of conduct](#scope-of-indemnification-and-standard-of-conduct).
 
-This determination must be made by (a) a majority vote of Councilors who were not
-party to the action, even if less than a quorum, or (b) the members of the
-Foundation.
+This determination must be made by (a) a majority vote of Councilors who were not party to the action, even if less than a quorum, or (b) the members of the Foundation.
 
-**Indemnification: Advance Payment.** The Foundation must advance expenses to an
-indemnified person defending a court action, so long as the indemnified person agrees to
-repay the advanced amount if the CFC ultimately determines the person was not entitled
-to indemnification.
+> [!TIP]
+> The Council must agree that the person deserves to be covered based on their behavior and the situation.
+> A majority of Councilors not involved in the issue, or the Foundation members, must decide.
 
-**Indemnification: Non-Exclusivity.** A person’s rights to indemnification and advance
-expenses under [this Section](#indemnification) are not exclusive of any other right to indemnification or advance expenses that the person may be entitled to.
+**Indemnification: Advance Payment.**
+The Foundation shall pay the expenses (including reasonable attorneys' fees) actually and reasonably incurred by a Covered Person in defending any Proceeding for which the Covered Person is entitled to indemnification under this section in advance of its final disposition, upon (a) written request from such person and (b) receipt of an undertaking[^1] by or on behalf of such person to repay all amounts advanced if it is ultimately determined that he or she is not entitled under applicable law to be indemnified by the Foundation.
 
-**Indemnification: Continuation; Advancement of Expenses.** A person’s right to
-indemnification and advancement of expenses under [this Section](#indemnification) shall continue
-after the person has ceased to be a Councilor, Officer, employee, or agent of the Foundation,
-and shall inure to the benefit of the heirs, executors and administrators of that person.
+[^1]: A “receipt of an undertaking” is a written promise from a person seeking indemnification. This promise states that they will repay any legal expenses advanced by the Foundation if it turns out they are not entitled to indemnification.
 
-**Indemnification: Severability.** If any part of [this Section](#indemnification) or any award made hereunder is determined to be invalid, the other provisions remain in full force and effect.
+**Indemnification: Non-Exclusivity.**
+A person’s rights to indemnification and advance expenses under this Section are not exclusive of any other right to indemnification or advance expenses that the person may be entitled to.
+
+**Indemnification: Continuation; Advancement of Expenses.**
+A person’s right to indemnification and advancement of expenses under this Section shall continue after the person has ceased to be a Councilor, Officer, employee, or agent of the Foundation, and shall inure to the benefit of the heirs, executors and administrators of that person.
+
+**Indemnification: Severability.**
+If any part of this Section or any award made hereunder is determined to be invalid, the other provisions remain in full force and effect.
+
+> [!TIP]
+>
+> - Advance Payment: The Foundation will pay costs upfront if requested in writing, but the person must promise to pay it back if it's decided they aren't covered.
+> - Non-Exclusivity: This coverage is in addition to any other rights they might have.
+> - Continuation: The coverage continues even after the person leaves the Foundation and benefits their heirs.
+> - Severability: If one part is invalid, the rest still applies.
 
 Relevant Florida Statutes:
 
@@ -78,7 +93,7 @@ Relevant Florida Statutes:
 - [607.0854](http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0600-0699/0607/Sections/0607.0854.html) Court-ordered indemnification and advance for expenses.
 - [607.0855](http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0600-0699/0607/Sections/0607.0855.html) Determination and authorization of indemnification.
 - [607.0858](http://www.leg.state.fl.us/Statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0600-0699/0607/Sections/0607.0858.html) Variation by corporate action; application of ss. 607.0850-607.0859.
-- [607.0859](http://www.leg.state.fl.us/Statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0600-0699/0607/Sections/0607.0859.html) Overriding restrictions on indemnification.
+- [607.0859](http://www.leg.state.fl.us/statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0600-0699/0607/Sections/0607.0859.html) Overriding restrictions on indemnification.
 
 ## Dissolution and Asset Distribution
 

--- a/bylaws/8-indemnification-dissolution.md
+++ b/bylaws/8-indemnification-dissolution.md
@@ -48,7 +48,7 @@ This indemnification does not extend to a person who is found liable to the Foun
 Otherwise, the outcome of an action will not alone create a presumption that a person did not act in good faith, in the best interests of the Foundation, or with lawful intent.
 
 > [!TIP]
-> If the Foundation brings a lawsuit against a person, or if the person is found responsible for wrongdoing in such a lawsuit, they will not be covered by this indemnification.
+> If the Foundation brings a lawsuit against a person, or if the person is found responsible for wrongdoing in such a lawsuit, that person will not be covered by this indemnification.
 > Being involved in a lawsuit does not mean the person did something wrong.
 
 Relevant Florida Statutes:


### PR DESCRIPTION
[![🗳️ Vote progress](https://www.commonhaus.org/votes/commonhaus/foundation/187.svg)](https://github.com/commonhaus/foundation/pull/187#issuecomment-2273807144 "IC_kwDOKRPTI86Hh4so")

For some context, I was thinking about our language after reading this: 

https://pyfound.blogspot.com/2024/07/notice-of-python-software-foundation.html
  
We were already reasonably constrained, but it seemed like constraining required/mandatory indemnification to the council/directors and officers at first makes the most sense. We can then allow the CFC to extend that indemnification to cover others (employees or committee members) when appropriate without requiring revisions to bylaws.

The revised text also clarifies that advance payments for indemnifications must be made in writing and include an acknowledgement to repay those funds if necessary

The language brings in more legal jargon, but I've included TIPs to try and keep things readable.

voting group: @commonhaus/cf-egc 

Do one of the following:

- Approve the PR or react with 👍 (:+1:) if it looks good to you
- Review with Comments or react with 👀 (:eyes:) if you're "ok" with it (it may not be your favorite)
- If you think it needs discussion or revision
    - Create a review, add your comments and require changes
    - Use the +- button to make a suggestion (instead of just adding a comment).