### PR TITLE
OpenRewrite withdraw

### DIFF
--- a/CONTACTS.yaml
+++ b/CONTACTS.yaml
@@ -46,8 +46,6 @@ egc:
     login: aalmiray
   - project: morphia
     login: evanchooly
-  - project: openrewrite
-    login: timtebeek
   - project: jackson
     login: cowtowncoder
     avatarAlt:  >-

--- a/FAQ.md
+++ b/FAQ.md
@@ -157,7 +157,7 @@ without requiring an externally-imposed structure.
 ## What types of open source projects does Commonhaus aim to support?
 
 The foundation is open to a wide range of open source projects.
-At launch, we are proud to include the Hibernate, Jackson, OpenRewrite, JBang, JReleaser,
+At launch, we are proud to include the Hibernate, Jackson, JBang, JReleaser,
 and Morphia projects, many of which are essential projects in the Java ecosystem today.
 Our doors are open to projects from all languages and technologies that share our vision
 for a collaborative and sustainable open source future.

--- a/PROJECTS.yaml
+++ b/PROJECTS.yaml
@@ -105,17 +105,6 @@ objenesis:
       Objenesis is a small Java library that serves one purpose: To instantiate a new object of a particular class
       WITHOUT calling one of its constructors.
 
-openrewrite:
-  name: OpenRewrite
-  repo: https://github.com/openrewrite
-  display:
-    home: https://docs.openrewrite.org/
-    logo: https://www.commonhaus.org/images/projects/OpenRewrite_WordmarkTM_MidnightBlue.png
-    logo-dark: https://www.commonhaus.org/images/projects/OpenRewrite_WordmarkTM_White.png
-    description: >
-      Automate the refactoring of your Java codebase. OpenRewrite offers scalable, safe, and idempotent
-      code transformations to modernize and maintain your applications.
-
 quarkus:
   name: Quarkus
   repo: https://github.com/quarkusio

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -10,7 +10,6 @@ Refer to our [branding guidelines](https://www.commonhaus.org/about/branding.htm
 The Commonhaus Foundation has the following registered trademarks in the United States and/or other countries:
 
 - Hibernate &reg; US Reg. #3135582 [^1]
-- OpenRewrite &reg; US Reg. #97792494 [^1]
 
 <!--
 The Commonhaus Foundation has registrations pending for the following trademarks:
@@ -29,7 +28,6 @@ The Commonhaus Foundation uses the following unregistered trademarks:
 - Jackson &trade; [^1]
 - Morphia &trade; [^1]
 - Objenesis &trade; [^1]
-- OpenRewrite &trade; [^1]
 - Quarkus &trade; [^1]
 - SDKMAN! &trade; [^1]
 - SlateDB &trade; [^1]
@@ -62,8 +60,6 @@ The Commonhaus Foundation uses the following unregistered trademarks:
     <img src="https://github.com/MorphiaOrg/morphia-docs/blob/master/supplemental-ui/img/logo.png?raw=true" alt="" height="22" />
 - Objenesis Logo &trade; [^1]  
     <img src="https://github.com/easymock/objenesis/blob/master/website/site/resources/objenesis-logo.png?raw=true" alt="" height="22" />
-- OpenRewrite Logo &trade; [^1]  
-    <img src="https://www.commonhaus.org/images/OpenRewrite_WordmarkTM_MidnightBlue.png" alt="" height="22" />
 - Quarkus Logo &trade; [^1]  
     <img src="https://github.com/quarkusio/quarkus/blob/main/core/deployment/src/main/resources/META-INF/branding/logo.png?raw=true" alt="" height="22" />
 - SDKMAN! Logo &trade; [^1]  

--- a/agreements/bootstrapping/2024-03-25-bootstrapping-openrewrite-withdrawn.md
+++ b/agreements/bootstrapping/2024-03-25-bootstrapping-openrewrite-withdrawn.md
@@ -1,11 +1,14 @@
 # Commonhaus Foundation Bootstrapping Agreement
 
+### NOTE: OpenRewrite was withdrawn from Commonhaus before the formation period concluded. Below is a record of the original bootstrapping agreement.
+
 - Project: OpenRewrite
 - EGC representative: jkschneider
 
 This document outlines the preliminary, non-binding agreement for the establishment phase of the Commonhaus Foundation (CF), aiming to foster a collaborative community dedicated to open source projects.
 
 - [Commonhaus Foundation Bootstrapping Agreement](#commonhaus-foundation-bootstrapping-agreement)
+    - [NOTE: OpenRewrite was withdrawn from Commonhaus before the formation period concluded. Below is a record of the original bootstrapping agreement.](#note-openrewrite-was-withdrawn-from-commonhaus-before-the-formation-period-concluded-below-is-a-record-of-the-original-bootstrapping-agreement)
   - [EGC Quorum Establishment](#egc-quorum-establishment)
   - [Preliminary Commitment](#preliminary-commitment)
   - [Formation Period](#formation-period)

--- a/policies/trademark-guidelines.md
+++ b/policies/trademark-guidelines.md
@@ -4,11 +4,12 @@ This document provides practical guidance on the proper use of the Commonhaus Fo
 
 These guidelines are intended to support respectful and legally compliant use of the Foundation’s trademarks, preserving their integrity and meaning for our community.
 
-- [Proper trademark use](#proper-trademark-use)
+- [Trademark Information and Guidelines](#trademark-information-and-guidelines)
+  - [Proper trademark use](#proper-trademark-use)
     - [Trademark marking and legends](#trademark-marking-and-legends)
     - [Use of trademarks in text](#use-of-trademarks-in-text)
     - [Use of Logos](#use-of-logos)
-- [General information about Trademarks](#general-information-about-trademarks)
+  - [General information about Trademarks](#general-information-about-trademarks)
     - [What is a trademark?](#what-is-a-trademark)
     - [What is "likelihood of confusion"?](#what-is-likelihood-of-confusion)
     - [What is "nominative" use?](#what-is-nominative-use)
@@ -35,8 +36,8 @@ If you are using our Marks as described in the [Trademark Policy][], please incl
     - Correct: Hibernate, HIBERNATE
 
 - **Use trademarks in their exact form with correct spelling.** Do not abbreviate, hyphenate, or combine with other words.
-    - Incorrect: Open Rewrite, open rewrite, open-rewrite
-    - Correct: OpenRewrite
+    - Incorrect: Easy Mock, easy mock, easy-mock
+    - Correct: EasyMock
     - See our [Trademark List][] to verify exactly how the marks should appear.
 
 - **Use trademarks as adjectives modifying nouns**, especially the first time they appear in print. Refer to our preferred nouns on the [Trademark List][].

--- a/policies/trademark-policy.md
+++ b/policies/trademark-policy.md
@@ -7,18 +7,28 @@ Our trademarks—including the Commonhaus Foundation name, logo, and any project
 >
 > Trademark law can be ambiguous, so we aim to provide enough clarity for you to understand whether we will consider your use acceptable, either because it is licensed or it is non-infringing.
 
-- [Purpose and Scope](#purpose-and-scope)
-- [Commitment to Open Source principles](#commitment-to-open-source-principles)
-- [Covered Trademarks](#covered-trademarks)
-- [Trademark usage guidelines](#trademark-usage-guidelines)
-- [Restrictions on Similar Trademarks](#restrictions-on-similar-trademarks)
+- [Trademark Policy](#trademark-policy)
+  - [Purpose and Scope](#purpose-and-scope)
+  - [Commitment to Open Source principles](#commitment-to-open-source-principles)
+  - [Covered Trademarks](#covered-trademarks)
+  - [Trademark usage guidelines](#trademark-usage-guidelines)
+  - [Restrictions on Similar Trademarks](#restrictions-on-similar-trademarks)
     - [Uses we consider non-infringing](#uses-we-consider-non-infringing)
+      - [Distribution of unmodified source code or artifacts packaged by us](#distribution-of-unmodified-source-code-or-artifacts-packaged-by-us)
+      - [Distribution of modified source code or artifacts packaged by you](#distribution-of-modified-source-code-or-artifacts-packaged-by-you)
+      - [Statements about compatibility, interoperability or derivation](#statements-about-compatibility-interoperability-or-derivation)
+      - [Use of trademarks to show community affiliation](#use-of-trademarks-to-show-community-affiliation)
+      - [Websites](#websites)
+      - [Publications and presentations](#publications-and-presentations)
+      - [Events](#events)
     - [Uses for which we are granting a license](#uses-for-which-we-are-granting-a-license)
+      - [User groups](#user-groups)
+      - [Promotional goods](#promotional-goods)
     - [Uses we consider infringing without seeking further permission from us](#uses-we-consider-infringing-without-seeking-further-permission-from-us)
     - [Reporting Abuse or Seeking Information](#reporting-abuse-or-seeking-information)
-- [Policy modifications and updates](#policy-modifications-and-updates)
-- [Contact and further information](#contact-and-further-information)
-- [Attribution](#attribution)
+  - [Policy modifications and updates](#policy-modifications-and-updates)
+  - [Contact and further information](#contact-and-further-information)
+  - [Attribution](#attribution)
 
 ## Purpose and Scope
 
@@ -127,7 +137,7 @@ Acceptable usage examples:
 - *&lt;your product/company name>* **is powered by** Jackson
 - *&lt;your product/company name>* **plugin for** JReleaser
 - *&lt;your product/company name>* **extension for** Quarkus
-- *&lt;your product/company name>* **recipe for** OpenRewrite
+- *&lt;your product/company name>* **recipe for** EasyMock
 - *&lt;your product name>* **build of** Morphia
 
 Counter-examples (may cause confusion):


### PR DESCRIPTION
This PR serves as the formal withdrawal of OpenRewrite from Commonhaus in the bootstrapping period. When OpenRewrite first joined early on, much of what is now proposed as the formal structure of the foundation was not yet developed. We have used these last months to observe the structure as it formed, offer input along the way, and challenge the proposed structure in ways that would allow OpenRewrite to continue to be part of the foundation after the bootstrapping period ended. **We still believe in the future of Commonhaus** and the value it adds to projects and their community, but the bootstrapping period has revealed to us some differences in directional vision that we feel are unresolvable.

I don't believe this PR needs approval from a group, since I am the ECG representative of the project in the bootstrapping period prior to everything being formalized.

I'll try to summarize what we have learned, in the spirit of being helpful to others:

## Commonhaus is not as confederate as we imagined, and that’s OK

When OpenRewrite originally joined, what we imagined was really twofold: (1) a depository for the trademark and (2) for every other administrative aspect of the project an opt-in structure that delegated to the project as much administration as the project was willing to perform on its own.

For (1) the goal was to provide some assurance that OpenRewrite core would continue to be fully open source (a commitment Moderne still holds to).

For (2) we imagined a foundation that consisted of projects with varying degrees of legal and administrative power behind them already. For example, Moderne has already been defending the OpenRewrite trademark on its own and has the financial wherewithal to do that, but I wouldn’t expect the same from Jackson who doesn’t have the same corporate infrastructure (at least I think so). Our needs are perhaps different, and we thought an opt-in structure supported us both in our different situations.

As the bootstrapping period has unfolded, it became clear that the foundation is unwilling to fully delegate some administrative functions to projects. In the case of the Trademark policy in particular, the foundation believes it is in fact _necessary_ to force some constraints on the project, a legal opinion we do not share. We can respectfully disagree on the specifics on this point, but maybe the important takeaway is that such a _à la carte_ delegatory confederation as we imagined either isn’t possible or simply isn’t what the foundation wants. And that is OK!

## Policy development

The proposed Trademark policy in particular became a lightning rod for us as early forms of the policy appeared to preclude our team from using the OpenRewrite brand iconography in creative and fun ways that weren't anticipated by the policy. We had been anticipating splitting the icon up into brightly colored assets and using them in physical displays. Something like:

![image](https://github.com/user-attachments/assets/83e6dc29-11c0-4095-b514-4cda928071fc)

This kind of fun 3D isomorphic view on the Moderne website also apparently violated the policy:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6d51095d-edc5-4584-add0-1fad91f49a31">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/865d2558-e7da-43d2-83d4-a03d84529352">

We communicated many of these concerns and were repeatedly assured by @ebullient that the _intent_ of the policy was to enforce against potential abusers of the brand not against the developers of the project, and we do believe in the sincerity of Erin's stance. But it continued to be a concern that some future foundation leadership may not feel the same way, and feeling so constrained just... didn't feel right.

This conversation, trivial as it might seem, revealed I suppose the larger concern for us as a project.

## Voting structure

With a majoritarian voting structure, policies could realistically be changed at any time, including to be more restrictive, in ways that could be well meaning but cause harm to the company Moderne (and other contributors) which pours so much energy and investment into the project.

I don't have an obvious solution for this. Clearly any one participating project blocking adoption of policy changes could substantially alter the ability of the foundation to stay relevant under changing circumstances. So perhaps this is best seen as a foreseeable consequence of committee oversight that, at any rate, wasn't apparent until some of these policies began to be circulated.

## A warm farewell I hope

I want to once again reaffirm my admiration for the foundation and what it has set out to do, and hope you understand that we acted in good faith to find a path to inclusion. I also hope you’ll appreciate the tremendous pressure we are under as a project whose future is entwined with our livelihoods as well – a project that is in some cases being exploited commercially by larger companies with no return of value to the project. We will continue to work to find our own way in building software together in the open as much as possible.
