### PR TITLE
Correct Code of Conduct importance in the policypanda tool

### DIFF
--- a/templates/PolicyPanda.java
+++ b/templates/PolicyPanda.java
@@ -148,7 +148,7 @@ public class PolicyPanda implements Runnable {
                     }
                 });
 
-                checkFile(repo, globalRepo, "Code of conduct", "Code of conduct file", "CODE_OF_CONDUCT", Kind.SHOULD);
+                checkFile(repo, globalRepo, "Code of conduct", "Code of conduct file", "CODE_OF_CONDUCT", Kind.MUST);
 
                 System.out.println("## " + repo.getFullName());
                 checks.get(repo.getFullName()).stream().forEach(check -> {


### PR DESCRIPTION
According to https://github.com/commonhaus/foundation/blob/main/templates/README.md conde of conduct should be marked as 'MUST' by the panda tool. This PR should correct that.
