### PR TITLE
Correct Contibuting guide importance in the policypanda tool

### DIFF
--- a/templates/PolicyPanda.java
+++ b/templates/PolicyPanda.java
@@ -137,7 +137,7 @@ public class PolicyPanda implements Runnable {
                     }
                 }
 
-                checkFile(repo, globalRepo, "Contributing guide", "Contributing guide present", "CONTRIBUTING", Kind.SHOULD, (content, contentString) -> {
+                checkFile(repo, globalRepo, "Contributing guide", "Contributing guide present", "CONTRIBUTING", Kind.MUST, (content, contentString) -> {
                     switch(agreementType) {
                         case DCO -> {
                             addCheck(repo, new check("DCO", "Contributing guide should mention DCO", repo, Kind.SHOULD, contentString.matches("(?s).*\\(DCO\\).*"), content));


### PR DESCRIPTION
I hadn't noticed this one in my previous PR but contributing guide should ALSO be marked as 'MUST' by the panda tool (
https://github.com/commonhaus/foundation/blob/main/templates/README.md).