### PR TITLE
Adding myself as egc-second for Quarkus

### DIFF
--- a/CONTACTS.yaml
+++ b/CONTACTS.yaml
@@ -100,6 +100,8 @@ egc-second:
     login: JooHyukKim
   - project: infinispan
     login: karesti
+  - projet: quarkus
+    login: Sanne
 
 #--------------------------------------------------------------------------
 # Advisory Board members (sponsor-appointed)


### PR DESCRIPTION
Updating the `CONTACTS.yaml` to track myself as egc fallback for Quarkus.

Since @dandreadis is the primary, I guess this needs reviewed by him?