### PR TITLE
Clarify Project Representation vs Project Lead

### DIFF
--- a/bylaws/1-preface.md
+++ b/bylaws/1-preface.md
@@ -34,7 +34,7 @@ The [foundation][] repository is the authoritative source for Commonhaus Foundat
 
 The CF Council (CFC) must review bylaws at least annually to ensure ongoing compliance with applicable laws and regulations.
 
-The [Extended Governance Committee (EGC)][egc] (EGC: CFC + Project Leads) jointly review and approve bylaw changes.
+The [Extended Governance Committee (EGC)][egc] (EGC: CFC + Project Representatives) jointly review and approve bylaw changes.
 
 Amendments or changes to Bylaws will follow the [amendment process][].
 

--- a/bylaws/4-cf-council.md
+++ b/bylaws/4-cf-council.md
@@ -90,7 +90,7 @@ Expanding beyond the CFC, the Extended Governance Committee (EGC) plays a vital 
 
 This structure ensures a balanced representation, combining strategic oversight with project-specific insights.
 
-An up-to-date list of Project Leads as members of the EGC will be maintained in the `egc` [CONTACTS.yaml][] attribute.
+An up-to-date list of Project Representatives as members of the EGC will be maintained in the `egc` [CONTACTS.yaml][] attribute.
 
 ## Meetings, Procedures and Decision-Making
 


### PR DESCRIPTION
This PR clarifies that the EGC is made up of Project Representatives (not necessarily the same as Project Leads and/or Signatories)
