### PR TITLE
Correct Boundary Regex in PolicyPanda

### DIFF
--- a/templates/panda/PolicyPanda.java
+++ b/templates/panda/PolicyPanda.java
@@ -203,7 +203,7 @@ public class PolicyPanda extends CommonhausPanda implements Runnable {
                 // Check if contributing mentions DCO
                 if (repoFiles.contributing() != null) {
                     String content = readContent(repoFiles.contributing());
-                    boolean hasDcoMention = content.matches("(?is).*\b(DCO|Developer Certificate of Origin)\b.*");
+                    boolean hasDcoMention = content.matches("(?is).*\\b(DCO|Developer Certificate of Origin)\\b.*");
                     addCheck(repo, new ContentCheck("DCO Reference", "DCO mentioned in CONTRIBUTING",
                             Kind.MUST, hasDcoMention, repoFiles.contributing()));
                 }
@@ -215,7 +215,7 @@ public class PolicyPanda extends CommonhausPanda implements Runnable {
                 // Check if contributing mentions CLA
                 if (repoFiles.contributing() == null) {
                     String content = readContent(repoFiles.contributing());
-                    boolean hasCLAMention = content.matches("(?is).*\b(CLA|Contributor License Agreement)\b.*");
+                    boolean hasCLAMention = content.matches("(?is).*\\b(CLA|Contributor License Agreement)\\b.*");
                     addCheck(repo, new ContentCheck("CLA Reference", "CLA mentioned in CONTRIBUTING",
                             Kind.MUST, hasCLAMention, repoFiles.contributing()));
                 }


### PR DESCRIPTION
Running PolicyPanda against Kroxylicious was producing a spurious `DCO Reference` exception.
Issue is Java requires backslashes to be escaped.  



<!-- 
If you create a pull request that modifies policies or bylaws,
the description will be used in an email to the announcement list.
Explain your changes and hook a reviewer... 

If this PR needs approval/consensus from a group, include something like the following: 

voting group: @...

Do one of the following:

- Approve the PR or react with 👍 (:+1:) if it looks good to you
- Review with Comments or react with 👀 (:eyes:) if you're "ok" with it (it may not be your favorite)
- If you think it needs discussion or revision
    - Create a review, add your comments and require changes
    - Use the +- button to make a suggestion (instead of just adding a comment).

-->
