### PR TITLE
Add Tom Jenkinson as the EGC secondary for WildFly

### DIFF
--- a/CONTACTS.yaml
+++ b/CONTACTS.yaml
@@ -112,6 +112,8 @@ egc-second:
     login: yrodiere
   - project: kroxylicious
     login: SamBarker
+  - project: wildfly
+    login: tomjenkinson
 
 #--------------------------------------------------------------------------
 # Advisory Board members (sponsor-appointed)


### PR DESCRIPTION
I don't _think_ this needs approval/consensus from a group so I didn't include the voting language.
