### PR TITLE
Updates the panda tool for checking repository compliance to fix a couple of errors 

### DIFF
--- a/templates/panda/PolicyPanda.java
+++ b/templates/panda/PolicyPanda.java
@@ -153,21 +153,26 @@ public class PolicyPanda extends CommonhausPanda implements Runnable {
     private void runPolicyCheck(List<GHRepository> repos) throws IOException {
         log.info("🌳 Running policy check...");
 
-        CommunityFiles orgFiles = findCommunityFiles(orgDotGithubRepo);
-        if (orgFiles.governance() != null) {
-            addCheck(orgDotGithubRepo,
-                    new Item("Organization %s file found"
-                            .formatted(orgFiles.governance().getName())));
-        }
-        if (orgFiles.codeOfConduct() != null) {
-            addCheck(orgDotGithubRepo,
-                    new Item("Organization %s file found"
-                            .formatted(orgFiles.codeOfConduct().getName())));
-        }
-        if (orgFiles.contributing() != null) {
-            addCheck(orgDotGithubRepo,
-                    new Item("Organization %s file found"
-                            .formatted(orgFiles.contributing().getName())));
+        CommunityFiles orgFiles;
+        if (orgDotGithubRepo != null) {
+            orgFiles = findCommunityFiles(orgDotGithubRepo);
+            if (orgFiles.governance() != null) {
+                addCheck(orgDotGithubRepo,
+                        new Item("Organization %s file found"
+                                .formatted(orgFiles.governance().getName())));
+            }
+            if (orgFiles.codeOfConduct() != null) {
+                addCheck(orgDotGithubRepo,
+                        new Item("Organization %s file found"
+                                .formatted(orgFiles.codeOfConduct().getName())));
+            }
+            if (orgFiles.contributing() != null) {
+                addCheck(orgDotGithubRepo,
+                        new Item("Organization %s file found"
+                                .formatted(orgFiles.contributing().getName())));
+            }
+        } else {
+            orgFiles = new CommunityFiles(null, null, null);
         }
 
         // Process each repository

--- a/templates/panda/PolicyPanda.java
+++ b/templates/panda/PolicyPanda.java
@@ -6,6 +6,7 @@
 //DEPS org.kohsuke:github-api:1.327
 //DEPS ./CommonhausPanda.java
 
+import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -252,30 +253,47 @@ public class PolicyPanda extends CommonhausPanda implements Runnable {
                             "Branch %s is not protected".formatted(branch.getName())));
 
                     if (branch.isProtected()) {
+                        boolean allowForcePushes = true;
+                        boolean allowDeletions = true;
+                        boolean enforceAdmins = false;
+                        boolean codeOwnerReviewRequired = false;
+                        boolean reviewRequired = false;
                         try {
                             GHBranchProtection protection = branch.getProtection();
-                            addCheck(repo, new Check(!protection.getAllowForcePushes().isEnabled(), Kind.BONUS,
-                                    "Branch %s does not allow force pushes".formatted(branch.getName()),
-                                    "Branch %s allows force pushes".formatted(branch.getName())));
-                            addCheck(repo, new Check(!protection.getAllowDeletions().isEnabled(), Kind.BONUS,
-                                    "Branch %s does not allow deletions".formatted(branch.getName()),
-                                    "Branch %s allows deletions".formatted(branch.getName())));
-                            addCheck(repo, new Check(protection.getEnforceAdmins().isEnabled(), Kind.BONUS,
-                                    "Branch %s enforces admin rules".formatted(branch.getName()),
-                                    "Branch %s does not enforce admin rules".formatted(branch.getName())));
+                            allowForcePushes = protection.getAllowForcePushes().isEnabled();
+                            allowDeletions = protection.getAllowDeletions().isEnabled();
+                            enforceAdmins = protection.getEnforceAdmins().isEnabled();
                             var requiredReviews = branch.getProtection().getRequiredReviews();
                             if (codeowners != null) {
-                                addCheck(repo, new Check(requiredReviews != null && requiredReviews.isRequireCodeOwnerReviews(), Kind.BONUS,
-                                        "Branch %s requires reviews from code owners".formatted(branch.getName()),
-                                        "Branch %s does not require reviews from code owners".formatted(branch.getName())));
+                                codeOwnerReviewRequired = requiredReviews != null &&requiredReviews.isRequireCodeOwnerReviews();
+                                reviewRequired = codeOwnerReviewRequired;
                             } else {
-                                addCheck(repo, new Check(requiredReviews != null && protection.getRequiredReviews().getRequiredReviewers() > 0, Kind.BONUS,
-                                        "Branch %s requires code review".formatted(branch.getName()),
-                                        "Branch %s does not require code review".formatted(branch.getName())));
+                                reviewRequired = requiredReviews != null && protection.getRequiredReviews().getRequiredReviewers() > 0;
                             }
+                        } catch (FileNotFoundException ignore) {
+                            // This is 404 response. The protection might be set to true, but protection: { enabled: false}
+                            // might be set. We will assume the defaults
                         } catch (IOException e) {
                             throw new UncheckedIOException(
                                     "Failed to get branch protection for %s".formatted(branch.getName()), e);
+                        }
+                        addCheck(repo, new Check(!allowForcePushes, Kind.BONUS,
+                                "Branch %s does not allow force pushes".formatted(branch.getName()),
+                                "Branch %s allows force pushes".formatted(branch.getName())));
+                        addCheck(repo, new Check(!allowDeletions, Kind.BONUS,
+                                "Branch %s does not allow deletions".formatted(branch.getName()),
+                                "Branch %s allows deletions".formatted(branch.getName())));
+                        addCheck(repo, new Check(enforceAdmins, Kind.BONUS,
+                                "Branch %s enforces admin rules".formatted(branch.getName()),
+                                "Branch %s does not enforce admin rules".formatted(branch.getName())));
+                        if (codeOwnerReviewRequired) {
+                            addCheck(repo, new Check(reviewRequired, Kind.BONUS,
+                                    "Branch %s requires reviews from code owners".formatted(branch.getName()),
+                                    "Branch %s does not require reviews from code owners".formatted(branch.getName())));
+                        } else {
+                            addCheck(repo, new Check(reviewRequired, Kind.BONUS,
+                                    "Branch %s requires code review".formatted(branch.getName()),
+                                    "Branch %s does not require code review".formatted(branch.getName())));
                         }
                     }
                 });


### PR DESCRIPTION
While using this tool to check the https://github.com/resteasy/resteasy repository I found a couple of errors. 

The first being there was an expectation that a `.github` repository existed. While the simple workaround would be to create the repository, I felt it better to fall back to `null` values for the check to complete instead of throw an NPE.

The second fix is for repositories that may have protection enabled, but the branch itself is not protected. This is a JSON snippet:
```json
 "protected": true,
  "protection": {
    "enabled": false,
    "required_status_checks": {
      "enforcement_level": "off",
      "contexts": [],
      "checks": []
    }
  },
```

The tools if `protected` is `true`, but you get a 404 if `protection: { enabled: false}` is defined.
