### PR TITLE
By default, skip archived repositories, but allow them to be included.

### DIFF
--- a/templates/panda/PolicyPanda.java
+++ b/templates/panda/PolicyPanda.java
@@ -19,7 +19,6 @@ import java.util.stream.Stream;
 import org.kohsuke.github.GHBranchProtection;
 import org.kohsuke.github.GHContent;
 import org.kohsuke.github.GHOrganization;
-import org.kohsuke.github.GHOrganization.Role;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
 
@@ -68,6 +67,10 @@ public class PolicyPanda extends CommonhausPanda implements Runnable {
 
     @Option(names = { "-p", "--project-id" }, description = "Project ID to use in the YAML")
     private String projectId;
+
+    @Option(names = {"-i",
+            "--include-archived"}, description = "Include repositories in the organization that have been archived", defaultValue = "false")
+    private boolean includeArchived;
 
     @Option(names = { "-s",
             "--skip-policy-check" }, description = "Skip policy compliance check", defaultValue = "false")
@@ -125,6 +128,7 @@ public class PolicyPanda extends CommonhausPanda implements Runnable {
             List<GHRepository> filteredRepos = allRepos.stream()
                     .filter(repo -> !repo.getName().equals(".github"))
                     .filter(repo -> repoPattern.matcher(repo.getName()).matches())
+                    .filter(repo -> !(!includeArchived && repo.isArchived()))
                     .toList();
             log.info("Found " + filteredRepos.size() + " repositories matching the pattern");
 

--- a/templates/panda/README.md
+++ b/templates/panda/README.md
@@ -72,6 +72,7 @@ All reports are saved to the `reports` directory by default.
 | `-o, --output-dir` | Output directory for reports | `"reports"` |
 | `-p, --project-id` | Project ID to use in YAML reports | Organization name (lowercase) |
 | `-s, --skip-policy-check` | Skip policy compliance check | `false` |
+| `-i, --include-archived` | Included repositories that are archived | `false` |
 | `-a, --init-asset-discovery` | Generate asset discovery document | `false` |
 | `-g, --init-org-settings` | Generate organization settings report | `false` |
 | `-v, --verbose` | Verbosity level (off, info, fine, finer, finest, all) | `"info"` |


### PR DESCRIPTION
We could do the opposite of this and include repositories that are archived and allow them to be disabled. However, it seemed like they could be ignored since you'd have to un-archive them to make changes.